### PR TITLE
Add simple Tkinter UI for AD join

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Usage of the script:
 for ./ADconnection.sh do a 
 
      sudo chmod +x ADconnection.sh  
+You can also use the Python version:
+    sudo python3 adconnection_app.py [domain] [--user ADMIN] [--ou OU]
+    sudo python3 adconnection_gui.py
+
 
 
 # Complete steps

--- a/adconnection_app.py
+++ b/adconnection_app.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cmd(cmd):
+    try:
+        result = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        sys.exit(e.returncode)
+
+
+def discover_domain():
+    """Attempt to discover the AD domain using realm"""
+    try:
+        output = run_cmd("realm discover 2>/dev/null | awk '/realm.name/ {print $2; exit}'")
+        return output if output else None
+    except SystemExit:
+        return None
+
+
+def join_domain(domain, admin_user, ou=None):
+    cmd = ["realm", "join", "-v", f"--user={admin_user}"]
+    if ou:
+        cmd.append(f"--computer-ou={ou}")
+    cmd.append(domain)
+    run_cmd(" ".join(cmd))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Join Linux host to Active Directory")
+    parser.add_argument("domain", nargs="?", help="Domain to join")
+    parser.add_argument("-u", "--user", required=False, help="Admin user for the join")
+    parser.add_argument("-o", "--ou", help="OU for computer object")
+    parser.add_argument("--discover", action="store_true", help="Only discover domain")
+    args = parser.parse_args()
+
+    if args.discover:
+        domain = discover_domain()
+        if domain:
+            print(domain)
+        else:
+            print("No domain discovered")
+        return
+
+    domain = args.domain or discover_domain()
+    if not domain:
+        print("Domain could not be discovered. Please specify the domain as argument.")
+        sys.exit(1)
+
+    admin_user = args.user or input("Admin user: ")
+    join_domain(domain, admin_user, args.ou)
+    print(f"Successfully joined {domain}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/adconnection_gui.py
+++ b/adconnection_gui.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Simple Tkinter GUI to join a Linux host to Active Directory."""
+import subprocess
+import tkinter as tk
+from tkinter import messagebox
+
+
+def run_cmd(cmd):
+    """Run a shell command and return output and exit code."""
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout.strip(), result.returncode
+
+
+def discover_domain():
+    """Try to auto-discover the domain using realm."""
+    out, _ = run_cmd("realm discover 2>/dev/null | awk '/realm.name/ {print $2; exit}'")
+    return out
+
+
+def join_domain(domain, admin_user, ou):
+    cmd = ["realm", "join", "-v", f"--user={admin_user}"]
+    if ou:
+        cmd.append(f"--computer-ou={ou}")
+    cmd.append(domain)
+    return run_cmd(" ".join(cmd))
+
+
+def on_join():
+    domain = domain_var.get().strip()
+    user = user_var.get().strip()
+    ou = ou_var.get().strip()
+    if not domain:
+        messagebox.showerror("Error", "Domain is required")
+        return
+    if not user:
+        messagebox.showerror("Error", "Admin user is required")
+        return
+    output, code = join_domain(domain, user, ou)
+    if code == 0:
+        messagebox.showinfo("Success", f"Successfully joined {domain}")
+    else:
+        messagebox.showerror("Join Failed", output or "Unknown error")
+
+
+root = tk.Tk()
+root.title("AD Connection")
+
+# Variables
+domain_var = tk.StringVar(value=discover_domain() or "")
+user_var = tk.StringVar()
+ou_var = tk.StringVar()
+
+# Layout
+
+tk.Label(root, text="Domain:").grid(row=0, column=0, sticky="e", padx=5, pady=5)
+tk.Entry(root, textvariable=domain_var, width=40).grid(row=0, column=1, padx=5, pady=5)
+tk.Label(root, text="Admin User:").grid(row=1, column=0, sticky="e", padx=5, pady=5)
+tk.Entry(root, textvariable=user_var, width=40).grid(row=1, column=1, padx=5, pady=5)
+tk.Label(root, text="Computer OU:").grid(row=2, column=0, sticky="e", padx=5, pady=5)
+tk.Entry(root, textvariable=ou_var, width=40).grid(row=2, column=1, padx=5, pady=5)
+tk.Button(root, text="Join Domain", command=on_join).grid(row=3, column=0, columnspan=2, pady=10)
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- create `adconnection_gui.py` with a Tkinter-based interface for joining a Linux host to Active Directory
- document how to run the GUI in the README alongside the CLI Python app

## Testing
- `python3 -m py_compile adconnection_gui.py adconnection_app.py`
- `shellcheck ADconnection.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe4864a1c8324b367ff75fc9a6526